### PR TITLE
Allow fetching all user transactions without specifying date range

### DIFF
--- a/zlotowka-backend/src/main/java/com/agh/zlotowka/controller/GeneralTransactionController.java
+++ b/zlotowka-backend/src/main/java/com/agh/zlotowka/controller/GeneralTransactionController.java
@@ -83,8 +83,8 @@ public class GeneralTransactionController {
             @PathVariable Integer userId,
             @RequestParam(defaultValue = "1") Integer page,
             @RequestParam(defaultValue = "20") Integer limit,
-            @RequestParam(defaultValue = "2025-01-01") @DateAfter2000 LocalDate startDate,
-            @RequestParam(defaultValue = "2025-07-01") @DateAfter2000 LocalDate endDate,
+            @RequestParam(required = false) @DateAfter2000 LocalDate startDate,
+            @RequestParam(required = false) @DateAfter2000 LocalDate endDate,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         generalTransactionService.validateUserId(userId, userDetails);

--- a/zlotowka-backend/src/main/java/com/agh/zlotowka/repository/OneTimeTransactionRepository.java
+++ b/zlotowka-backend/src/main/java/com/agh/zlotowka/repository/OneTimeTransactionRepository.java
@@ -19,6 +19,9 @@ public interface OneTimeTransactionRepository extends JpaRepository<OneTimeTrans
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
 
+    @Query("SELECT t FROM OneTimeTransaction t WHERE t.user.userId = :userId")
+    List<OneTimeTransaction> findAllByUserId(@Param("userId") int userId);
+
     @Query("SELECT t FROM OneTimeTransaction t WHERE t.user.userId = :userId AND t.date > :now AND t.isIncome=TRUE ORDER BY t.date ASC LIMIT 1")
     Optional<OneTimeTransaction> getNextIncomeOneTimeTransactionByUser(@Param("userId") int userId, @Param("now") LocalDate now);
 

--- a/zlotowka-backend/src/main/java/com/agh/zlotowka/repository/RecurringTransactionRepository.java
+++ b/zlotowka-backend/src/main/java/com/agh/zlotowka/repository/RecurringTransactionRepository.java
@@ -1,5 +1,6 @@
 package com.agh.zlotowka.repository;
 
+import com.agh.zlotowka.model.OneTimeTransaction;
 import com.agh.zlotowka.model.RecurringTransaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -46,4 +47,8 @@ public interface RecurringTransactionRepository extends JpaRepository<RecurringT
             @Param("userId") int userId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+
+    @Query("SELECT rt FROM RecurringTransaction rt WHERE rt.user.userId = :userId AND rt.nextPaymentDate > CURRENT_DATE ")
+    List<RecurringTransaction> findAllByUserId(@Param("userId") int userId);
 }


### PR DESCRIPTION
- Made `startDate` and `endDate` optional in transaction paging endpoint
- Adjusted logic to return all transactions if dates are not provided